### PR TITLE
Added divider between Headline and Detailed news also changed heading color to black

### DIFF
--- a/app/src/main/res/layout/activity_detailnews.xml
+++ b/app/src/main/res/layout/activity_detailnews.xml
@@ -15,6 +15,7 @@
         android:layout_marginRight="8dp"
         android:text="TextView"
         android:textAlignment="center"
+        android:textColor="@android:color/black"
         android:textSize="24sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -27,8 +28,23 @@
         android:layout_marginLeft="8dp"
         android:layout_marginTop="8dp"
         android:layout_marginRight="8dp"
+        android:paddingLeft="4dp"
+        android:paddingRight="4dp"
         android:text="TextView"
         android:textAlignment="center"
+        android:textSize="16sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/divider" />
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="0dp"
+        android:layout_height="4dp"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="10dp"
+        android:background="#7A7A7A"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/txtNewsHeading" />


### PR DESCRIPTION


__30__ 

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
<!-- Add issue numbers both above and below this comment, do not remove __ or #-->

Fixes #30 

#### Short description of what this resolves:
Added a divider.


#### Changes proposed in this pull request and/or Screenshots of changes:

-
-
-



